### PR TITLE
Add periodic table layout

### DIFF
--- a/layouts/index.njk
+++ b/layouts/index.njk
@@ -10,13 +10,13 @@
 <br/>
 
 <h2>Quantum Gate Periodic Table</h2>
+<p class="periodic-explanation">Each cell shows the gate symbol with its
+arity and quDit dimension in the top right (e.g. <code>2q2d</code> for a
+two‑qubit gate).</p>
 <div class="periodic-table">
   {% for gate in collections.gates %}
   <a class="periodic-cell" href="{{ gate.url }}">
-    <div class="top-row">
-      <span class="group">{{ gate.data.groups[0] }}</span>
-      <span class="arity-dim">{{ gate.data.arity }}q{{ gate.data.dimension | default(2) }}d</span>
-    </div>
+    <span class="arity-dim">{{ gate.data.arity }}q{{ gate.data.dimension | default(2) }}d</span>
     <div class="symbol">${{ gate.data.symbol | safe }}$</div>
     <div class="name">{{ gate.data.title }}</div>
   </a>

--- a/layouts/index.njk
+++ b/layouts/index.njk
@@ -13,6 +13,10 @@
 <div class="periodic-table">
   {% for gate in collections.gates %}
   <a class="periodic-cell" href="{{ gate.url }}">
+    <div class="top-row">
+      <span class="group">{{ gate.data.groups[0] }}</span>
+      <span class="arity-dim">{{ gate.data.arity }}q{{ gate.data.dimension | default(2) }}d</span>
+    </div>
     <div class="symbol">${{ gate.data.symbol | safe }}$</div>
     <div class="name">{{ gate.data.title }}</div>
   </a>

--- a/layouts/index.njk
+++ b/layouts/index.njk
@@ -9,13 +9,15 @@
 
 <br/>
 
-<h2>Gates</h2>
-<p>Quantum gates, or gates for short, are individual or families of elements of the unitary group $\mathsf{U}(n)$.</p>
-<ul>
+<h2>Quantum Gate Periodic Table</h2>
+<div class="periodic-table">
   {% for gate in collections.gates %}
-  <li><a href="{{ gate.url }}">{{ gate.data.title }}</a></li>
+  <a class="periodic-cell" href="{{ gate.url }}">
+    <div class="symbol">${{ gate.data.symbol | safe }}$</div>
+    <div class="name">{{ gate.data.title }}</div>
+  </a>
   {% endfor %}
-</ul>
+</div>
 
 <br/>
 

--- a/styles/base.css
+++ b/styles/base.css
@@ -86,7 +86,8 @@ footer {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
     gap: 10px;
-    margin-top: 20px;
+    margin: 20px auto 0;
+    width: 600px;
 }
 
 .periodic-table a {
@@ -103,26 +104,27 @@ footer {
     font-family: sans-serif;
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
+    align-items: center;
+    position: relative;
 }
 
-.periodic-cell .top-row {
-    display: flex;
-    justify-content: space-between;
+
+
+.periodic-cell .arity-dim {
     font-size: 10px;
-    margin-bottom: 4px;
+    position: absolute;
+    top: 2px;
+    right: 2px;
 }
 
 .periodic-cell .symbol {
     font-size: 20px;
     font-weight: bold;
+    margin-top: 6px;
 }
 
 .periodic-cell .name {
     font-size: 12px;
-}
-
-.periodic-cell .group,
-.periodic-cell .arity-dim {
-    font-size: 10px;
+    margin-top: auto;
+    margin-bottom: 4px;
 }

--- a/styles/base.css
+++ b/styles/base.css
@@ -94,12 +94,23 @@ footer {
     color: black;
 }
 
+
 .periodic-cell {
     border: 1px solid black;
     padding: 10px;
     background: var(--gradient2);
     text-align: center;
     font-family: sans-serif;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+}
+
+.periodic-cell .top-row {
+    display: flex;
+    justify-content: space-between;
+    font-size: 10px;
+    margin-bottom: 4px;
 }
 
 .periodic-cell .symbol {
@@ -109,4 +120,9 @@ footer {
 
 .periodic-cell .name {
     font-size: 12px;
+}
+
+.periodic-cell .group,
+.periodic-cell .arity-dim {
+    font-size: 10px;
 }

--- a/styles/base.css
+++ b/styles/base.css
@@ -81,3 +81,32 @@ footer {
 
     background: var(--gradient2);
 }
+
+.periodic-table {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+    gap: 10px;
+    margin-top: 20px;
+}
+
+.periodic-table a {
+    text-decoration: none;
+    color: black;
+}
+
+.periodic-cell {
+    border: 1px solid black;
+    padding: 10px;
+    background: var(--gradient2);
+    text-align: center;
+    font-family: sans-serif;
+}
+
+.periodic-cell .symbol {
+    font-size: 20px;
+    font-weight: bold;
+}
+
+.periodic-cell .name {
+    font-size: 12px;
+}


### PR DESCRIPTION
## Summary
- redesign the homepage to list gates in a periodic table grid
- style new periodic table tiles

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6843e7337040832cb606c698f3bcf0e2