### PR TITLE
Fix paths for GitHub Pages

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -25,6 +25,7 @@ module.exports = function (eleventyConfig) {
   });
 
   return {
+    pathPrefix: process.env.PATH_PREFIX || "/",
     markdownTemplateEngine: "njk",
     htmlTemplateEngine: "njk",
     dataTemplateEngine: "njk",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,11 @@ jobs:
           node-version: '22.x'
 
       - name: Install dependencies & build
+        env:
+          PATH_PREFIX: "/gate.directory/"
         run: |
           npm ci
-          npm run build          
+          npm run build
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+gate.directory

--- a/README.md
+++ b/README.md
@@ -20,3 +20,9 @@ The website is built with static site generator [11ty](https://www.11ty.dev/), a
     npm run serve
     ```
 4. The `npm run serve` command will indicate which port the pages are being served from on your machine.
+
+When deploying to GitHub Pages the build uses a path prefix of `/gate.directory/` so asset URLs resolve correctly. Locally you can override this with the `PATH_PREFIX` environment variable:
+
+```sh
+PATH_PREFIX=/ npm run build
+```

--- a/layouts/base.njk
+++ b/layouts/base.njk
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="stylesheet" href="/styles/base.css">
-  <link rel="stylesheet" href="/styles/gate.css">
+  <link rel="stylesheet" href="{{ '/styles/base.css' | url }}">
+  <link rel="stylesheet" href="{{ '/styles/gate.css' | url }}">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css" integrity="sha384-nB0miv6/jRmo5UMMR1wu3Gz6NLsoTkbqJghGIsx//Rlm+ZU03BU6SQNC66uf4l5+" crossorigin="anonymous">
 
     <!-- The loading of KaTeX is deferred to speed up page rendering -->
@@ -19,7 +19,7 @@
   <main>
     <div class="content-container">
       <header>
-          <h1 class="header-title"><a href="/">quantum gate directory</a></h1>
+          <h1 class="header-title"><a href="{{ '/' | url }}">quantum gate directory</a></h1>
         </header>
       <div class="not-footer">
         

--- a/layouts/gate.njk
+++ b/layouts/gate.njk
@@ -28,11 +28,11 @@
     <p>This gate is contained in the following groups:</p>
     <ul>
       {% for group in groups %}
-      <li><a href="/groups/{{ group }}">{{ group }}</a></li>
+      <li><a href="{{ '/groups/' + group | url }}">{{ group }}</a></li>
       {% endfor %}
     </ul>
   {% endif %}
 
-  <a class="back-to-home" href="/">Back to home</a>
+  <a class="back-to-home" href="{{ '/' | url }}">Back to home</a>
 </div>
 {% endblock %}

--- a/layouts/gate.njk
+++ b/layouts/gate.njk
@@ -28,7 +28,7 @@
     <p>This gate is contained in the following groups:</p>
     <ul>
       {% for group in groups %}
-      <li><a href="{{ '/groups/' + group | url }}">{{ group }}</a></li>
+      <li><a href="{{ ('/groups/' + group) | url }}">{{ group }}</a></li>
       {% endfor %}
     </ul>
   {% endif %}

--- a/layouts/group.njk
+++ b/layouts/group.njk
@@ -12,7 +12,7 @@
 <ul>
 {% for gate in gates %}
     {% if group in gate.groups %}
-        <li><a href="{{ '/gates/' + gate | url }}">{{ gate }}</a></li>
+        <li><a href="{{ ('/gates/' + gate) | url }}">{{ gate }}</a></li>
     {% endif %}
 {% endfor %}
 </ul>

--- a/layouts/group.njk
+++ b/layouts/group.njk
@@ -12,7 +12,7 @@
 <ul>
 {% for gate in gates %}
     {% if group in gate.groups %}
-        <li><a href="/gates/{{ gate }}">{{ gate }}</a></li>
+        <li><a href="{{ '/gates/' + gate | url }}">{{ gate }}</a></li>
     {% endif %}
 {% endfor %}
 </ul>


### PR DESCRIPTION
## Summary
- add `CNAME` for custom domain
- use `url` filter for links and assets so they honor `PATH_PREFIX`
- configure Eleventy to read `PATH_PREFIX` environment variable
- update GitHub workflow to set the prefix during builds
- document how to override the path prefix when building locally

## Testing
- `npm run build`
- `PATH_PREFIX=/ npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685a310b40f8832cbf3abd0238020030