### PR TITLE
Fix mobile layout and math rendering

### DIFF
--- a/layouts/base.njk
+++ b/layouts/base.njk
@@ -11,8 +11,7 @@
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" integrity="sha384-7zkQWkzuo3B5mTepMUcHkMB5jZaolc2xDwL6VFqjFALcbeS9Ggm/Yr2r3Dy4lfFg" crossorigin="anonymous"></script>
 
     <!-- To automatically render math in text elements, include the auto-render extension: -->
-    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" integrity="sha384-43gviWU0YVjaDtb/GhzOouOXtZMP/7XUzwPTstBeZFe/+rCMvRwr4yROQP43s0Xk" crossorigin="anonymous"
-        onload="renderMathInElement(document.body);"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" integrity="sha384-43gviWU0YVjaDtb/GhzOouOXtZMP/7XUzwPTstBeZFe/+rCMvRwr4yROQP43s0Xk" crossorigin="anonymous"></script>
   <title>{{ title or "Quantum Gate Directory" }}</title>
 </head>
 <body>
@@ -33,14 +32,17 @@
     </div>
   </main>
   <script>
-    document.addEventListener("DOMContentLoaded", function() {
-      renderMathInElement(document.body, {
-        delimiters: [
-          {left: "$$", right: "$$", display: true},
-          {left: "$", right: "$", display: false}
-        ]
-      });
-    });
+    function renderPageMath() {
+      if (window.renderMathInElement) {
+        renderMathInElement(document.body, {
+          delimiters: [
+            {left: "$$", right: "$$", display: true},
+            {left: "$", right: "$", display: false}
+          ]
+        });
+      }
+    }
+    window.addEventListener("load", renderPageMath);
   </script>
 </body>
 </html>

--- a/styles/base.css
+++ b/styles/base.css
@@ -47,7 +47,8 @@ main {
 }
 
 .content-container {
-    width: 800px;
+    width: 100%;
+    max-width: 800px;
     display: flex;
     flex-wrap: wrap;
     flex-direction: column;
@@ -87,7 +88,8 @@ footer {
     grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
     gap: 10px;
     margin: 20px auto 0;
-    width: 600px;
+    width: 100%;
+    max-width: 600px;
 }
 
 .periodic-table a {


### PR DESCRIPTION
## Summary
- make content container responsive
- make periodic table responsive
- call math rendering on window load so it works on mobile

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685dc7a2fad0832ca4985a5637bef5e8